### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/data_utils/file_utils.py
+++ b/data_utils/file_utils.py
@@ -113,8 +113,8 @@ def get_file(fname, origin, untar=False,
 
     if download:
         from urllib.parse import urlparse
-        parsed_url = urlparse(origin)
-        if parsed_url.hostname == "modac.cancer.gov":
+        host = urlparse(origin).hostname
+        if host and (host == "modac.cancer.gov" or host.endswith(".modac.cancer.gov")):
             get_file_from_modac(fpath, origin)
         else:
             print('Downloading data from', origin)

--- a/data_utils/file_utils.py
+++ b/data_utils/file_utils.py
@@ -112,7 +112,9 @@ def get_file(fname, origin, untar=False,
     '''
 
     if download:
-        if 'modac.cancer.gov' in origin:
+        from urllib.parse import urlparse
+        parsed_url = urlparse(origin)
+        if parsed_url.hostname == "modac.cancer.gov":
             get_file_from_modac(fpath, origin)
         else:
             print('Downloading data from', origin)


### PR DESCRIPTION
Potential fix for [https://github.com/CBIIT/NCI-DOE-Collab-Pilot3-Multitask-Convolutional-Neural-Network/security/code-scanning/1](https://github.com/CBIIT/NCI-DOE-Collab-Pilot3-Multitask-Convolutional-Neural-Network/security/code-scanning/1)

To fix the issue, the code should parse the `origin` URL and validate its hostname to ensure it matches the intended domain (`modac.cancer.gov`). This can be achieved using Python's `urllib.parse` module to extract the hostname and then checking if it matches the expected domain. This approach avoids the pitfalls of substring checks and ensures that only URLs with the exact intended domain or subdomains are accepted.

The changes will involve:
1. Importing `urlparse` from `urllib.parse`.
2. Replacing the substring check `'modac.cancer.gov' in origin` with a proper hostname validation using `urlparse`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
